### PR TITLE
<♻️refactor>:[server: prisma]:{Rename Session table to sessions}

### DIFF
--- a/server/prisma/migrations/20250317155820_refactor_sessions_table/migration.sql
+++ b/server/prisma/migrations/20250317155820_refactor_sessions_table/migration.sql
@@ -11,7 +11,7 @@
 ALTER TABLE `comments` DROP FOREIGN KEY `comments_df_su_id_fkey`;
 
 -- DropForeignKey
-ALTER TABLE `session` DROP FOREIGN KEY `Session_session_user_id_fkey`;
+ALTER TABLE `Session` DROP FOREIGN KEY `Session_session_user_id_fkey`;
 
 -- DropIndex
 DROP INDEX `comments_df_su_id_fkey` ON `comments`;
@@ -23,7 +23,7 @@ ALTER TABLE `comments` DROP COLUMN `df_su_id`,
     ADD COLUMN `cm_su_id` INTEGER NOT NULL;
 
 -- DropTable
-DROP TABLE `session`;
+DROP TABLE `Session`;
 
 -- CreateTable
 CREATE TABLE `sessions` (


### PR DESCRIPTION
แก้ไขปัญหา migrate ไม่ได้เพราะชื่อ session เป็นตัวพิมเล็กตอนแรก ทำให้มีปัญหาบนเครื่อง Linux OS
![image](https://github.com/user-attachments/assets/f8e3211a-3afa-4097-8ca5-3669a9055a4a)
